### PR TITLE
add-model-itemimg

### DIFF
--- a/app/models/itemimg.rb
+++ b/app/models/itemimg.rb
@@ -1,0 +1,5 @@
+class Itemimg < ApplicationRecord
+  belongs_to :item
+  
+  mount_uploader :image, ImageUploader
+end

--- a/db/migrate/20200522064538_create_itemimgs.rb
+++ b/db/migrate/20200522064538_create_itemimgs.rb
@@ -1,0 +1,9 @@
+class CreateItemimgs < ActiveRecord::Migration[5.2]
+  def change
+    create_table :itemimgs do |t|
+      t.text :image, null: false
+      #t.references :item, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,21 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_05_22_064538) do
+
+  create_table "itemimgs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "image", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/test/fixtures/itemimgs.yml
+++ b/test/fixtures/itemimgs.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/itemimg_test.rb
+++ b/test/models/itemimg_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ItemimgTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
 # What
 - itemimgのmodelを作成
 - migrateファイル
    itemモデルがないのでitem_idをreferencesできないため、コメントアウトしている。

# Why
 - item（商品）の画像を作成し、ユーザー間で商品をイメージできるようにするため。