### PR TITLE
[fix]  商品出品画面でjsが読み込まれないバグを修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,8 +30,8 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to root_path, notice: "商品を出品しました"
     else
-      flash.now[:alert] = "必須項目をすべて入力してください"
-      render :new
+      flash[:alert] = "必須項目をすべて入力してください"
+      redirect_to action: :new
     end
   end
 


### PR DESCRIPTION
# What
 -  レンダリングの修正
 - items controllerのcreateアクション内の「render」を「redirect_to」に変更した。
# Why
 - 商品出品画面で入力漏れがあった場合は、renderで newアクションを再度呼び出すが、その際に画像投稿部分のJSが読み込めていないため
