### PR TITLE
商品購入ページ、商品出品テスト修正

### DIFF
--- a/app/assets/stylesheets/cards/purchaseConfilmation.scss
+++ b/app/assets/stylesheets/cards/purchaseConfilmation.scss
@@ -28,6 +28,12 @@
         }
         .item-detail {
           margin-left: 16px;
+          .item-detail__name {
+            overflow: hidden;
+            display: -webkit-box;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: 2;
+          }
         }
       }
     }

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -8,12 +8,9 @@ FactoryBot.define do
     preparation_day_id        { 1 }
     item_condition_id         { 1 }
     postage_payer_id          { 1 }
-    postage_type_id           { 1 }
-    size_id                   { 1 }
     # ↓referenceキー
     category                  { create(:category) }
     seller                    { create(:user) }
-    buyer                     { create(:user, email: "nnn@gmail.com") } # sellerのuserとは違うアドレスで、異なるuserとして設定している
     brand                     { create(:brand) }
 
     # ↓1枚の画像をアップロードする

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -56,28 +56,10 @@ describe Item do
         expect(item.errors[:postage_payer_id]).to include("を入力してください")
       end
 
-      it "postage_type_idがない場合は登録できないこと" do
-        item = build(:item, :image1, postage_type_id: "")
-        item.valid?
-        expect(item.errors[:postage_type_id]).to include("を入力してください")
-      end
-
       it "seller_idがない場合は登録できないこと" do
         item = build(:item, :image1, seller_id: "")
         item.valid?
         expect(item.errors[:seller_id]).to include("を入力してください")
-      end
-
-      it "buyer_idがない場合は登録できないこと" do
-        item = build(:item, :image1, buyer_id: "")
-        item.valid?
-        expect(item.errors[:buyer_id]).to include("を入力してください")
-      end
-
-      it "size_idがない場合は登録できないこと" do
-        item = build(:item, :image1, size_id: "")
-        item.valid?
-        expect(item.errors[:size_id]).to include("を入力してください")
       end
 
       it "imagesがない場合は登録できないこと" do

--- a/spec/models/size_spec.rb
+++ b/spec/models/size_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Size, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
# What
 - 商品購入ページの商品名がoveflowして表示しないように修正した。
 - 商品出品テストをバリデーションとマイグレーションファイルにあわせて修正した。

# Why
 - 投稿内容によってビュー崩れがおきないようにするため。
 - 本番環境でエラーが起きないようにするため。
