### PR TITLE
画像編集がされないバグを修正

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,7 +2,6 @@ class Item < ApplicationRecord
   belongs_to :item_size, optional: true
   belongs_to :category
   belongs_to :brand, optional: true
-  has_many :images, dependent: :destroy
   belongs_to :seller,   class_name: 'User'
   belongs_to :buyer, class_name: 'User', optional: true
   has_many :images, dependent: :destroy


### PR DESCRIPTION
# What
 - 商品編集時に画像だけ更新されないバグを修正
 - has_many :images の記述が重複していたため、一つを削除
