### PR TITLE
エラーハンドリング　修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -127,8 +127,7 @@ class ItemsController < ApplicationController
   def purchaseCompleted; end
 
   def sold_out
-    @item = Item.find(params[:id])
-    redirect_to root_path if @item.trading_status == "売り切れ"
+    redirect_to root_path if @item.trading_status == "売り切れ" || @item.seller_id == current_user.id
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,6 +5,7 @@ class ItemsController < ApplicationController
   before_action :set_sending_destinations, only: %i[purchaseConfilmation]
   before_action :set_api_key
   before_action :return_unless_seller, only: %i[edit update destroy]
+  before_action :sold_out, only: %i[purchaseConfilmation pay purchaseCompleted]
   require 'payjp'
 
   def index
@@ -124,6 +125,11 @@ class ItemsController < ApplicationController
   end
 
   def purchaseCompleted; end
+
+  def sold_out
+    @item = Item.find(params[:id])
+    redirect_to root_path if @item.trading_status == "売り切れ"
+  end
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,7 +5,7 @@ class ItemsController < ApplicationController
   before_action :set_sending_destinations, only: %i[purchaseConfilmation]
   before_action :set_api_key
   before_action :return_unless_seller, only: %i[edit update destroy]
-  before_action :sold_out, only: %i[purchaseConfilmation pay purchaseCompleted]
+  before_action :sold_out, only: %i[purchaseConfilmation]
   require 'payjp'
 
   def index
@@ -112,22 +112,26 @@ class ItemsController < ApplicationController
   end
 
   def pay
-    charge = Payjp::Charge.create(
-      amount: @item.price, # 支払金額を引っ張ってくる
-      customer: @card.customer_id, # 顧客ID
-      currency: 'jpy' # 日本円
-    )
-    @item_buyer = Item.find(params[:id])
-    @item_buyer.update(buyer_id: current_user.id)
-    @item_trading = Item.find(params[:id])
-    @item_trading.update(trading_status: 1)
-    redirect_to purchaseCompleted_item_path # 購入完了ページへ
+    if @item.seller_id == current_user.id
+      redirect_to root_path
+    else
+      charge = Payjp::Charge.create(
+        amount: @item.price, # 支払金額を引っ張ってくる
+        customer: @card.customer_id, # 顧客ID
+        currency: 'jpy' # 日本円
+      )
+      @item_buyer = Item.find(params[:id])
+      @item_buyer.update(buyer_id: current_user.id)
+      @item_trading = Item.find(params[:id])
+      @item_trading.update(trading_status: 1)
+      redirect_to purchaseCompleted_item_path # 購入完了ページへ
+    end
   end
 
   def purchaseCompleted; end
 
   def sold_out
-    redirect_to root_path if @item.trading_status == "売り切れ" || @item.seller_id == current_user.id
+    redirect_to root_path if @item.trading_status == "売り切れ"
   end
 
   private


### PR DESCRIPTION
# What
 - 自身が出品した商品は、支払いを作成するアクション(Payjp::Charge.createをするアクション)を動かせないようになっている
 - 一度購入された商品の購入画面へURLを直打ちしても飛べなくなっている
 - 一度購入された商品は、支払いを作成するアクション(Payjp::Charge.createをするアクション)を動かせないようになっている

# Why
 - ビュー側を改竄されて、不正アクセスで被害が発生するかもしれないから。
