### PR TITLE
商品サイズ表示のエラー修正

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -46,15 +46,15 @@
             %tr
               %th ブランド
               %td 
-            %tr
-              %th 商品のサイズ 
-              %td 
-                = @item.item_size.size
+            - if @item.item_size.present?
+              %tr
+                %th 商品のサイズ 
+                %td 
+                  = @item.item_size.size
             %tr
               %th 商品の状態
               %td 
                 = @item.item_condition.name
-
             %tr
               %th 配送料の負担
               %td 


### PR DESCRIPTION
# What
 - 商品サイズが選択されてにないときに、詳細ページでエラーとなる問題を修正した。
 - 条件分岐で、サイズが選択されてにないときは、サイズの行を表示しないようにした。

